### PR TITLE
No more Marionette.addEventBinder

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -28,7 +28,7 @@ define( [
             this.options = options || {};
             this.parentContext = this.options.parentContext;
             this.vent = {};
-            Marionette.addEventBinder(this.vent);
+            _.extend(this.vent, Backbone.Events);
             this.initialize && this.initialize();
             this._contextId = _.uniqueId("Context");
             contexts[this._contextId] = this;
@@ -93,12 +93,14 @@ define( [
         };
 
         Geppetto.Context.prototype.mapCommand = function mapCommand( eventName, commandClass ) {
-
+            
+            var _this = this;
+            
             this.vent.listenTo( this.vent, eventName, function ( eventData ) {
 
                 var commandInstance = new commandClass();
 
-                commandInstance.context = this;
+                commandInstance.context = _this;
                 commandInstance.eventName = eventName;
                 commandInstance.eventData = eventData;
                 commandInstance.execute && commandInstance.execute();


### PR DESCRIPTION
Marionette v1.0.0-rc4 removed `Marionette.addEventBinder` in favor of the new `Backbone.Events`

This commit refactors Geppetto to use Backbone.Events for `context.vent`
