### PR TITLE
Enable example project to be served directly from the examples directory itself.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -48,7 +48,7 @@ chromium.org/developers/how-tos/chrome-frame-getting-started -->
 
 </footer>
 
-<script data-main="js/main" src="../dependencies/require.js"></script>
+<script data-main="js/main" src="js/lib/dependencies/require.js"></script>
 
 </body>
 </html>

--- a/examples/js/lib/backbone.geppetto.js
+++ b/examples/js/lib/backbone.geppetto.js
@@ -1,0 +1,1 @@
+../../../backbone.geppetto.js

--- a/examples/js/lib/dependencies
+++ b/examples/js/lib/dependencies
@@ -1,0 +1,1 @@
+../../../dependencies

--- a/examples/js/main.js
+++ b/examples/js/main.js
@@ -2,14 +2,14 @@
 
 require.config( {
     paths:{
-        jquery:'../../dependencies/jquery',
-        underscore:'../../dependencies/underscore',
-        backbone:'../../dependencies/backbone',
-        marionette:'../../dependencies/backbone.marionette',
-		'backbone.wreqr':'../../dependencies/backbone.wreqr',
-		'backbone.babysitter':'../../dependencies/backbone.babysitter',
-        geppetto:'../../backbone.geppetto',
-        text:'../../dependencies/text',
+        jquery:'lib/dependencies/jquery',
+        underscore:'lib/dependencies/underscore',
+        backbone:'lib/dependencies/backbone',
+        marionette:'lib/dependencies/backbone.marionette',
+		'backbone.wreqr':'lib/dependencies/backbone.wreqr',
+		'backbone.babysitter':'lib/dependencies/backbone.babysitter',
+        geppetto:'lib/backbone.geppetto',
+        text:'lib/dependencies/text',
         myapp:"src/my-app"
     },
 	shim: {


### PR DESCRIPTION
Created sym-links from backbone.geppetto and its dependencies in to new directory examples/js/lib, and updated the example project's requirejs config to point to them via that location rather than via the repository's root (which is outside the example's web-root when served directly from examples/). 

This seemed to be the simplest way to enable delivery when not served from the example's parent directory -- which might not be the obvious approach for anyone who doesn't do an npm install in order to run the test suites locally first... Adding a pair of sym-links felt less complex than trying to explain that the demo had to be served from the parent directory, since running a webserver there gives you an index page which leads to examples and text on the modeln github subdomain rather than pointing to the local option...
