### PR TITLE
3 minor additions

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -39,6 +39,8 @@
         }
         this._contextId = _.uniqueId("Context");
         contexts[this._contextId] = this;
+
+        this.mapCommands();
     };
 
     Geppetto.bindContext = function bindContext( options ) {
@@ -79,8 +81,6 @@
                 context.listen(view, eventName, view[callback]);
             }
         });
-
-        this.mapCommands();
 
         return context;
     };


### PR DESCRIPTION
Hey,

I've made three minor additions I find very useful:
- Make Context pass arguments from constructor to initialize() following backbone conventions
- Allow bindContext() to also take an existing context instead of constructor
- Automatically map commands in Context.commands property
  E.g.:
  commands: {
    'commandName': CommandConstructor
  }

I hope you find them useful. Best regards,

Jonas
