### PR TITLE
Minor fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ return Geppetto.Context.extend( {
 });
 ```
 
-**Option 2: Using the `mapCommand` function:**
+**Option 2: Using the `commands` map:**
 
 ```javascript
 return Geppetto.Context.extend( {


### PR DESCRIPTION
In 'registering commands' options 1 and 2 had the same description.
