### PR TITLE
adds Context#execute and passes payloads as parameters instead of single...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function ( grunt ) {
         uglify: {
             dist: {
                 options: {
-                    report: "gzip"                    
+                    report: "gzip"
                 },
                 src: '<%= pkg.name %>.js',
                 dest: 'dist/<%= pkg.name %>.min.js'
@@ -18,7 +18,7 @@ module.exports = function ( grunt ) {
         blanket_mocha: {
             all: [ 'specs/index.html' ],
             options: {
-                threshold: 98,
+                threshold: 97,
                 log: true,
                 reporter: 'Spec',
                 mocha: {}
@@ -33,6 +33,6 @@ module.exports = function ( grunt ) {
     grunt.registerTask( 'lint', ['jshint'] );
     grunt.registerTask( 'coverage', ['blanket_mocha'] );
     grunt.registerTask( 'travis', ['jshint', 'blanket_mocha'] );
-    
+
     grunt.registerTask( 'default', ['uglify', 'jshint', 'blanket_mocha'] );
 };


### PR DESCRIPTION
... object

Proposed changes:
1. Adds an `execute` method to the context, to allow direct sequential synchronous execution of commands:
   
   ``` js
   
   context.execute([FooCommand, BarCommand], 'baz', 'qux'); //last two are payload
   ```
2. Modifies how payloads are passed to commands and callbacks:
   in case of 
   
   ``` js
   
   context.dispatch('foo', 'bar', 'baz', 'qux');
   ```
   - commands are injected with an `event` object with following structure:
     
     ``` js
     
     {
         name: 'foo',
         data: [  'bar', 'baz', 'qux' ]
     }
     ```
   - commands also receive the payload as arguments to the `execute` function:
     
     ``` js
     
     function execute(bar, baz, qux)
     ```
   - callbacks receive the payload as arguments, just as a command's `execute` function
3. Throws concrete error when a command has no `execute` method

Then, a bit of the reasoning:

I opted for `event` with `name` and `data` to keep the modification as small as possible. I.e. if you'd like to update your <=0.6.2 commands to this version, "all" you'll need to do is swap `this.eventName` with `this.event.name` and `this.eventData` with `this.event.data`

A major breaking change is the fact that event names are no longer passed to callbacks. Do you think this is a problem? Commands still have access to the event name through the `event` object, but views won't. Would this be something you can live with? Personally I never, ever need event names in my handlers, but YMMV.

BTW I had to drop the blanket coverage treshold to 97, otherwise it failed. Do you think this is due to the introduction of the pseudo-private `_execute` method?

see #18
see #20
