### PR TITLE
Updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ command.prototype.execute = function () {
 return command;
 ```
 
-### Dependency Injection
+### Injected Data
 
 The Geppetto framework automatically injects a few things into each Command instance before it is executed.
 
@@ -415,6 +415,8 @@ The three injections are:
 * context
 * eventName
 * eventData
+
+They can be accessed as properties of the command object via `this`.
 
 See this example for their usage:
 


### PR DESCRIPTION
Updated the README by removing the term "Dependency Injection" as I found it quite confusing.

Dependency injection means the data is only injected when the object states it as a dependency. The current implementation always inject the data, whether the command needs it or not.

This may confuse other readers of the doc too.
