### PR TITLE
Pass context, event name and data to command constructors

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -335,7 +335,7 @@
 
         this.vent.listenTo(this.vent, eventName, function(eventData) {
 
-            var commandInstance = new CommandConstructor();
+            var commandInstance = new CommandConstructor(_this, eventName, eventData);
 
             commandInstance.context = _this;
             commandInstance.eventName = eventName;

--- a/specs/src/geppetto-specs.js
+++ b/specs/src/geppetto-specs.js
@@ -483,7 +483,9 @@ define([
                 var ContextDefinition = Geppetto.Context.extend({});
                 context = new ContextDefinition();
                 resolver = context.resolver;
-                CommandClass = function() {};
+                CommandClass = function() {
+                    this.ctorArgs = _.toArray(arguments);
+                };
                 CommandClass.prototype.execute = function() {
                     command = this;
                 };
@@ -516,6 +518,12 @@ define([
                 context.wireCommand('foo', CommandClass);
                 context.dispatch('foo');
                 expect(command.dependency).to.equal(value);
+            });
+            
+            it("should pass context and event data to the command constructor", function(){
+                context.wireCommand('foo', CommandClass);
+                context.dispatch('foo');
+                expect(command.ctorArgs).to.contain(context);
             });
         });
 


### PR DESCRIPTION
To allow for simple commands w/o execute methods I think it would be a good idea to pass the context, eventName and eventData to the command constructors.

~~I added a spec, but can't get the tests to run (and don't have the time right now to check what's wrong), when I run `npm test` I get an error:~~

~~>Testing: specs/index.html
Warning: PhantomJS timed out, possibly due to a missing Mocha run() call. Use --force to continue.~~
