### PR TITLE
Wire dependencies before context initialization

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -187,15 +187,15 @@
 
         this.vent = {};
         _.extend(this.vent, Backbone.Events);
-        if (_.isFunction(this.initialize)) {
-            this.initialize.apply(this, arguments);
-        }
         this._contextId = _.uniqueId("Context");
         contexts[this._contextId] = this;
 
         var wiring = this.wiring || this.options.wiring;
         if (wiring) {
             this._configureWirings(wiring);
+        }
+        if (_.isFunction(this.initialize)) {
+            this.initialize.apply(this, arguments);
         }
     };
 

--- a/specs/src/geppetto-specs.js
+++ b/specs/src/geppetto-specs.js
@@ -528,6 +528,8 @@ define([
             var abcSpy;
 
             var wiring;
+            
+            var isWiredBeforeInitialization;
 
             beforeEach(function() {
                 abcSpy = sinon.spy();
@@ -569,6 +571,8 @@ define([
 
                     }
                 };
+                
+                isWiredBeforeInitialization = false;
 
                 var ContextDefinition = Geppetto.Context.extend({
                     wiring: wiring,
@@ -579,7 +583,8 @@ define([
                         wireView: sinon.spy(),
                         resolve: sinon.spy(),
                         releaseAll: sinon.spy()
-                    }
+                    },
+                    initialize : sinon.spy()
                 });
 
                 context = new ContextDefinition();
@@ -617,6 +622,9 @@ define([
             it("should wire custom-mapped views", function() {
                 expect(context.resolver.wireView).to.be.calledWith("customWiredView",
                         wiring.views.customWiredView.ctor, wiring.views.customWiredView.wiring);
+            });
+            it("should wire everything before initialization", function(){
+                expect(context.resolver.wireSingleton).to.be.calledBefore(context.initialize);
             });
         });
 


### PR DESCRIPTION
As discussed in #43 call `context#initialize` last when instantiating a context.
Tests all pass, so I think there should be no problems. However, I suppose this could be a breaking change for some people..?
