### PR TITLE
Make compatible with CommonJS

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -7,7 +7,10 @@
 // http://modeln.github.com/backbone.geppetto/
 
 (function(factory) {
-    if (typeof define === "function" && define.amd) {
+    // CommonJS
+    if (typeof exports === "object") {
+        module.exports = factory(require('underscore'), require('backbone'));
+    } else if (typeof define === "function" && define.amd) {
         // Register as an AMD module if available...
         define(["underscore", "backbone"], factory);
     } else {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "url": "https://github.com/ModelN/backbone.geppetto/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "Gruntfile.js",
+  "main": "backbone.geppetto.js",
   "engines": {
     "node": ">= 0.8.0"
   },
@@ -30,7 +30,6 @@
     "test": "grunt travis --verbose"
   },
   "devDependencies": {
-    "backbone": "~1.1.0",
     "grunt": "~0.4.1",
     "grunt-blanket-mocha": "^0.4.0",
     "grunt-concurrent": "^0.5.0",
@@ -49,5 +48,9 @@
     "plugin",
     "command",
     "mvc"
-  ]
+  ],
+  "dependencies": {
+    "backbone": "~1.1.0",
+    "underscore": "^1.6.0"
+  }
 }


### PR DESCRIPTION
I'm moving away from RequireJS since it's so ... um ... I dunno, I just keep on struggling with it and I loathe the boilerplate. So I'm migrating to Browserify which is really awesome, especially since I do front and backend, which means I can use the same module importing syntax on both.
1. I added the necessary code to geppetto to allow it to be loaded CommonJS style
2. I moved "backbone" from being a dev dependency to being a real dependency and added underscore as a dependency as well. This allows the installation of geppetto through npm instead of bower
3. I changed "main" in package.json to point to the geppeto file. This allows loading geppetto with `require("backbone.geppetto")` otherwise you need to provide a path (i.e. `require("backbone.geppetto/backbone.geppetto")`)

I have no idea how to test this through mocha, so I did some manual testing and it all worked out. I looked at Marionette and they don't seem to be testing whether the framework's exposed as CommonJS module either.
