### PR TITLE
"apply" arguments to new view instead of "call"

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -75,7 +75,7 @@
             return OriginalConstructor.extend({
                 initialize: function() {
                     context.resolver.resolve(this, wiring);
-                    OriginalConstructor.prototype.initialize.call(this, arguments);
+                    OriginalConstructor.prototype.initialize.apply(this, arguments);
                 }
             });
         },


### PR DESCRIPTION
arguments pseudo-array is not a suitable parameter for a view's initialize method
