### PR TITLE
Fix parent context

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -80,11 +80,6 @@
             });
         },
 
-        createChildResolver: function() {
-            var child = new Resolver(this._context);
-            child.parent = this;
-            return child;
-        },
 
         getObject: function(key) {
             return this._retrieveFromCacheOrCreate(key, false);
@@ -182,10 +177,12 @@
 
         if (this.options.resolver) {
             this.resolver = this.options.resolver;
-        } else if (this.parentContext) {
-            this.resolver = this.parentContext.resolver.createChildResolver();
         } else if (!this.resolver) {
             this.resolver = new Resolver(this);
+        }
+        
+        if (this.parentContext){
+            this.resolver.parent = this.parentContext.resolver
         }
 
         this.vent = {};


### PR DESCRIPTION
context.parentContext just needs to be a reference to the parent context.

createChildResolver function not required. No need to go to the parent context to do anything as the parent has no need to be aware of the child's existence (it's the child that must reference the parent).

Original createChildResolver function was calling "child" a resolver based on the parent context as this._context is the parent context when the function is called.
