### PR TITLE
Optimize grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,5 @@
 module.exports = function(grunt) {
-
+    require('jit-grunt')(grunt);
     var browsers = [{
         browserName: "firefox",
         version: "25",
@@ -143,16 +143,13 @@ module.exports = function(grunt) {
         }
     });
 
-    // Loading dependencies
-    for (var key in grunt.file.readJSON("package.json").devDependencies) {
-        if (key !== "grunt" && key.indexOf("grunt") === 0) grunt.loadNpmTasks(key);
-    }
-
     grunt.registerTask('beautify', ['jsbeautifier:fix']);
     grunt.registerTask('lint', ['jshint']);
     grunt.registerTask('coverage', ['blanket_mocha']);
     grunt.registerTask('travis', ['jsbeautifier:check', 'jshint', 'blanket_mocha', 'connect']);
     grunt.registerTask("sauce", ['connect', 'saucelabs-mocha']);
 
-    grunt.registerTask('default', ['version', 'jsbeautifier:fix', 'uglify', 'jshint', 'blanket_mocha']);
+    grunt.registerTask('test', ['jsbeautifier:fix', 'jshint', 'blanket_mocha']);
+    grunt.registerTask('build', ['test', 'version', 'uglify']);
+    grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "grunt-open": "~0.2.2",
     "grunt-saucelabs": "^5.1.2",
     "grunt-version": "0.2.2",
+    "jit-grunt": "^0.8.0",
     "jquery": "^2.1.0",
     "mocha-unfunk-reporter": "~0.4.0"
   },


### PR DESCRIPTION
As discussed in #57 we needed a solution to avoid annoying merge conflicts of the minified file whenever several PR's are simultaneously outstanding.

I simply split the testing part into its own task. Easiest for now is that contributors run `grunt` which aliases to `grunt test` and leave the building to you, once you've merged the PR.
I've no idea how other libs handle the minified/binary files, except by leaving them out of the repo altogether.

As far as I'm concerned all my PR's can be merged, unless I missed something? 
