### PR TITLE
Fix Context#configure

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -444,6 +444,11 @@
         return this;
     };
 
+    Geppetto.Context.prototype.configure = function(key) {
+        this.resolver.configure.apply(this.resolver, arguments);
+        return this;
+    };
+
     Geppetto.Context.prototype.destroy = function destroy() {
         this.vent.stopListening();
         this.resolver.releaseAll();

--- a/specs/src/geppetto-specs.js
+++ b/specs/src/geppetto-specs.js
@@ -848,6 +848,66 @@ define([
             });
 
         });
+        
+        describe('when configuring wirings', function(){
+            var key = "key";
+            var passed;
+            var context;
+            var ctor = function(){
+                passed = _.toArray(arguments);
+            };
+            beforeEach(function(){
+                passed = null;
+                context = new Geppetto.Context();
+                context.wireClass(key, ctor);
+            });
+            afterEach(function(){
+                context.destroy();
+            });
+            it("should throw an error if no corresponding mapping was found", function() {
+                expect(function() {
+                    context.configure('unregistered key');
+                }).to.
+                throw (/no mapping found/);
+            });
+            it("should throw an error for wired values", function() {
+                context.wireValue('value', {});
+                expect(function() {
+                    context.configure('value');
+                }).to.
+                throw (/only possible for wirings of type singleton or class/);
+            });
+            it("should throw an error for wired views", function() {
+                context.wireView('view', function(){});
+                expect(function() {
+                    context.configure('view');
+                }).to.
+                throw (/only possible for wirings of type singleton or class/);
+            });
+            it('should pass an object as payload to the constructor function', function(){
+                var payload = {};
+                context.configure(key, payload);
+                context.getObject(key);
+                expect(passed[0]).to.equal(payload);
+            });
+            it('should call a function and pass its results as payload to the constructor function', function(){
+                var payload = {};
+                context.configure(key, function(){
+                    return payload;
+                });
+                context.getObject(key);
+                expect(passed[0]).to.equal(payload);
+            });
+            it('should pass all arguments as payload to the constructor function', function(){
+                var a = {};
+                var b = {};
+                context.configure(key, a, b);
+                context.getObject(key);
+                expect(passed[0]).to.equal(a);
+                expect(passed[1]).to.equal(b);
+            });
+        });
+        
 
         describe("when debug mode is enabled", function() {
 

--- a/specs/src/resolver-specs.js
+++ b/specs/src/resolver-specs.js
@@ -409,59 +409,6 @@ define([
                 expect(resolvedDependency ).to.be.instanceOf(clazz);
             });
         });
-        describe('when configuring wirings', function(){
-            var key = "key";
-            var passed;
-            var ctor = function(){
-                passed = _.toArray(arguments);
-            };
-            beforeEach(function(){
-                passed = null;
-                resolver.wireClass(key, ctor);
-            });
-            it("should throw an error if no corresponding mapping was found", function() {
-                expect(function() {
-                    resolver.configure('unregistered key');
-                }).to.
-                throw (/no mapping found/);
-            });
-            it("should throw an error for wired values", function() {
-                resolver.wireValue('value', {});
-                expect(function() {
-                    resolver.configure('value');
-                }).to.
-                throw (/only possible for wirings of type singleton or class/);
-            });
-            it("should throw an error for wired views", function() {
-                resolver.wireView('view', function(){});
-                expect(function() {
-                    resolver.configure('view');
-                }).to.
-                throw (/only possible for wirings of type singleton or class/);
-            });
-            it('should pass an object as payload to the constructor function', function(){
-                var payload = {};
-                resolver.configure(key, payload);
-                resolver.getObject(key);
-                expect(passed[0]).to.equal(payload);
-            });
-            it('should call a function and pass its results as payload to the constructor function', function(){
-                var payload = {};
-                resolver.configure(key, function(){
-                    return payload;
-                });
-                resolver.getObject(key);
-                expect(passed[0]).to.equal(payload);
-            });
-            it('should pass all arguments as payload to the constructor function', function(){
-                var a = {};
-                var b = {};
-                resolver.configure(key, a, b);
-                resolver.getObject(key);
-                expect(passed[0]).to.equal(a);
-                expect(passed[1]).to.equal(b);
-            });
-        });
     });
 
 });


### PR DESCRIPTION
Holy crap, I'm an idiot. I added the `configure` method to the resolver, but forgot to add a wrapper in Context. I als moved the `configure` tests from resolver-specs to context-specs to get full coverage.
