### PR TITLE
Updates

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -46,18 +46,86 @@
         };
     }
 
-    var Resolver = function(context) {
-        this._mappings = {};
-        this._context = context;
-        this.parent = undefined;
+    var extractConfig = function(def, key) {
+        var thisCtor, thisWiring;
+        if (def.hasOwnProperty("ctor")) {
+            thisCtor = def.ctor;
+            thisWiring = def.wiring;
+        } else {
+            thisCtor = def;
+        }
+        return [key, thisCtor, thisWiring];
     };
-    Resolver.prototype = {
+
+    var validateListen = function(target, eventName, callback) {
+
+        if (!_.isObject(target) || !_.isFunction(target.listenTo) || !_.isFunction(target.stopListening)) {
+            throw "Target for listen() must define a 'listenTo' and 'stopListening' function";
+        }
+
+        if (!_.isString(eventName)) {
+            throw "eventName must be a String";
+        }
+
+        if (!_.isFunction(callback)) {
+            throw "callback must be a function";
+        }
+    };
+
+    var Geppetto = {};
+
+    Geppetto.version = '0.7.0';
+
+    Geppetto.EVENT_CONTEXT_SHUTDOWN = "Geppetto:contextShutdown";
+
+    var contexts = {};
+
+    Geppetto.Context = function Context(options) {
+        this._mappings = {};
+
+        this.options = options || {};
+        this.parentContext = this.options.parentContext;
+
+        this.vent = {};
+        _.extend(this.vent, Backbone.Events);
+        this._contextId = _.uniqueId("Context");
+        contexts[this._contextId] = this;
+
+        var wiring = this.wiring || this.options.wiring;
+        if (wiring) {
+            this._configureWirings(wiring);
+        }
+        if (_.isFunction(this.initialize)) {
+            this.initialize.apply(this, arguments);
+        }
+    };
+
+    Geppetto.Context.extend = Backbone.View.extend;
+
+    _.extend(Geppetto.Context.prototype, {
+
+        _configureWirings: function _configureWirings(wiring) {
+            _.each(wiring.singletons, function(def, key) {
+                this.wireSingleton.apply(this, extractConfig(def, key));
+            }, this);
+            _.each(wiring.classes, function(def, key) {
+                this.wireClass.apply(this, extractConfig(def, key));
+            }, this);
+            _.each(wiring.values, function(value, key) {
+                this.wireValue(key, value);
+            }, this);
+            _.each(wiring.views, function(def, key) {
+                this.wireView.apply(this, extractConfig(def, key));
+            }, this);
+            this.wireCommands(wiring.commands);
+        },
+
         _createAndSetupInstance: function(config) {
             var instance;
             if (config.params) {
                 var params = _.map(config.params, function(param) {
                     if (_.isFunction(param)) {
-                        param = param(this._context);
+                        param = param(this);
                     }
                     return param;
                 }, this);
@@ -87,8 +155,8 @@
                         output = this._createAndSetupInstance(config);
                     }
                 }
-            } else if (this.parent && this.parent.hasWiring(key)) {
-                output = this.parent._retrieveFromCacheOrCreate(key, overrideRules);
+            } else if (this.parentContext && this.parentContext.hasWiring(key)) {
+                output = this.parentContext._retrieveFromCacheOrCreate(key, overrideRules);
             } else {
                 throw new Error(NO_MAPPING_FOUND + key);
             }
@@ -96,11 +164,11 @@
         },
 
         _wrapConstructor: function(clazz, wiring) {
-            var context = this._context;
+            var context = this;
             if (clazz.extend) {
                 return clazz.extend({
                     constructor: function() {
-                        context.resolver.resolve(this, wiring);
+                        context.resolve(this, wiring);
                         clazz.prototype.constructor.apply(this, arguments);
                     }
                 });
@@ -112,15 +180,96 @@
         _mapContextEvents: function(obj) {
             _.each(obj.contextEvents, function(callback, eventName) {
                 if (_.isFunction(callback)) {
-                    this._context.listen(obj, eventName, callback);
+                    this.listen(obj, eventName, callback);
                 } else if (_.isString(callback)) {
-                    this._context.listen(obj, eventName, obj[callback]);
+                    this.listen(obj, eventName, obj[callback]);
                 }
             }, this);
         },
 
-        getObject: function(key) {
-            return this._retrieveFromCacheOrCreate(key, false);
+        addPubSub: function(instance) {
+            instance.listen = _.bind(this.listen, this);
+            instance.dispatch = _.bind(this.dispatch, this);
+        },
+
+        listen: function listen(target, eventName, callback) {
+            validateListen(target, eventName, callback);
+            return target.listenTo(this.vent, eventName, callback, target);
+        },
+
+        listenToOnce: function listenToOnce(target, eventName, callback) {
+            validateListen(target, eventName, callback);
+            return target.listenToOnce(this.vent, eventName, callback, target);
+        },
+
+        dispatch: function dispatch(eventName, eventData) {
+            if (!_.isUndefined(eventData) && !_.isObject(eventData)) {
+                throw "Event payload must be an object";
+            }
+            eventData = eventData || {};
+            eventData.eventName = eventName;
+            this.vent.trigger(eventName, eventData);
+        },
+
+        dispatchToParent: function dispatchToParent(eventName, eventData) {
+            if (this.parentContext) {
+                this.parentContext.vent.trigger(eventName, eventData);
+            }
+        },
+
+        dispatchToParents: function dispatchToParents(eventName, eventData) {
+            if (this.parentContext && !(eventData && eventData.propagationDisabled)) {
+                this.parentContext.vent.trigger(eventName, eventData);
+                if (this.parentContext) {
+                    this.parentContext.dispatchToParents(eventName, eventData);
+                }
+            }
+        },
+
+        dispatchGlobally: function dispatchGlobally(eventName, eventData) {
+
+            _.each(contexts, function(context) {
+                if (!context) {
+                    return true;
+                }
+                context.vent.trigger(eventName, eventData);
+            });
+        },
+
+        wireCommand: function wireCommand(eventName, CommandConstructor, wiring) {
+
+            var context = this;
+
+            if (!_.isFunction(CommandConstructor)) {
+                throw "Command must be constructable";
+            }
+
+            this.vent.listenTo(this.vent, eventName, function(eventData) {
+
+                var commandInstance = new CommandConstructor(context, eventName, eventData);
+
+                commandInstance.context = context;
+                commandInstance.eventName = eventName;
+                commandInstance.eventData = eventData;
+                context.resolve(commandInstance, wiring);
+                if (_.isFunction(commandInstance.execute)) {
+                    commandInstance.execute();
+                }
+
+            });
+        },
+
+        wireCommands: function wireCommands(commandsMap) {
+            var _this = this;
+            _.each(commandsMap, function(mixedType, eventName) {
+                if (_.isArray(mixedType)) {
+                    _.each(mixedType, function(commandClass) {
+                        _this.wireCommand(eventName, commandClass);
+                    });
+                } else {
+                    _this.wireCommand(eventName, mixedType);
+                }
+            });
         },
 
         wireValue: function(key, useValue) {
@@ -130,10 +279,6 @@
                 type: TYPES.SINGLETON
             };
             return this;
-        },
-
-        hasWiring: function(key) {
-            return this._mappings.hasOwnProperty(key) || ( !! this.parent && this.parent.hasWiring(key));
         },
 
         wireClass: function(key, clazz, wiring) {
@@ -166,6 +311,25 @@
             return this;
         },
 
+        configure: function(key) {
+            var mapping = this._mappings[key];
+            if (typeof mapping === 'undefined') {
+                throw new Error(NO_MAPPING_FOUND + key);
+            }
+            if (!mapping.clazz || mapping.type === TYPES.VIEW) {
+                throw new Error("Cannot configure " + key + ": only possible for wirings of type singleton or class");
+            }
+            mapping.params = _.toArray(arguments).slice(1);
+        },
+
+        hasWiring: function(key) {
+            return this._mappings.hasOwnProperty(key) || ( !! this.parentContext && this.parentContext.hasWiring(key));
+        },
+
+        getObject: function(key) {
+            return this._retrieveFromCacheOrCreate(key, false);
+        },
+
         instantiate: function(key) {
             return this._retrieveFromCacheOrCreate(key, true);
         },
@@ -182,69 +346,27 @@
             this._mapContextEvents(instance);
             return this;
         },
-        addPubSub: function(instance) {
-            instance.listen = _.bind(this._context.listen, this._context);
-            instance.dispatch = _.bind(this._context.dispatch, this._context);
-        },
+
         release: function(key) {
             delete this._mappings[key];
-
             return this;
         },
+
         releaseAll: function() {
             this._mappings = {};
             return this;
         },
-        configure: function(key) {
-            var mapping = this._mappings[key];
-            if (typeof mapping === 'undefined') {
-                throw new Error(NO_MAPPING_FOUND + key);
-            }
-            if (!mapping.clazz || mapping.type === TYPES.VIEW) {
-                throw new Error("Cannot configure " + key + ": only possible for wirings of type singleton or class");
-            }
-            mapping.params = _.toArray(arguments).slice(1);
-        }
-    };
 
-    var Geppetto = {};
+        destroy: function destroy() {
+            this.vent.stopListening();
+            this.releaseAll();
 
-    Geppetto.version = '0.7.0';
+            delete contexts[this._contextId];
 
-    Geppetto.EVENT_CONTEXT_SHUTDOWN = "Geppetto:contextShutdown";
-
-    Geppetto.Resolver = Resolver;
-
-    var contexts = {};
-
-    Geppetto.Context = function Context(options) {
-
-        this.options = options || {};
-        this.parentContext = this.options.parentContext;
-
-        if (this.options.resolver) {
-            this.resolver = this.options.resolver;
-        } else if (!this.resolver) {
-            this.resolver = new Resolver(this);
+            this.dispatchToParent(Geppetto.EVENT_CONTEXT_SHUTDOWN);
         }
 
-        if (this.parentContext) {
-            this.resolver.parent = this.parentContext.resolver;
-        }
-
-        this.vent = {};
-        _.extend(this.vent, Backbone.Events);
-        this._contextId = _.uniqueId("Context");
-        contexts[this._contextId] = this;
-
-        var wiring = this.wiring || this.options.wiring;
-        if (wiring) {
-            this._configureWirings(wiring);
-        }
-        if (_.isFunction(this.initialize)) {
-            this.initialize.apply(this, arguments);
-        }
-    };
+    });
 
     Geppetto.bindContext = function bindContext(options) {
 
@@ -274,7 +396,7 @@
             context = this.options.context;
         }
 
-        context.resolver.resolve(view);
+        context.resolve(view);
 
         var returnValue;
 
@@ -288,191 +410,6 @@
 
         return returnValue;
     };
-
-    var extractConfig = function(def, key) {
-        var thisCtor, thisWiring;
-        if (def.hasOwnProperty("ctor")) {
-            thisCtor = def.ctor;
-            thisWiring = def.wiring;
-        } else {
-            thisCtor = def;
-        }
-        return [key, thisCtor, thisWiring];
-    };
-
-    Geppetto.Context.prototype._configureWirings = function _configureWirings(wiring) {
-        _.each(wiring.singletons, function(def, key) {
-            this.wireSingleton.apply(this, extractConfig(def, key));
-        }, this);
-        _.each(wiring.classes, function(def, key) {
-            this.wireClass.apply(this, extractConfig(def, key));
-        }, this);
-        _.each(wiring.values, function(value, key) {
-            this.wireValue(key, value);
-        }, this);
-        _.each(wiring.views, function(def, key) {
-            this.wireView.apply(this, extractConfig(def, key));
-        }, this);
-        this.wireCommands(wiring.commands);
-    };
-
-    var validateListen = function(target, eventName, callback) {
-
-        if (!_.isObject(target) || !_.isFunction(target.listenTo) || !_.isFunction(target.stopListening)) {
-            throw "Target for listen() must define a 'listenTo' and 'stopListening' function";
-        }
-
-        if (!_.isString(eventName)) {
-            throw "eventName must be a String";
-        }
-
-        if (!_.isFunction(callback)) {
-            throw "callback must be a function";
-        }
-    };
-
-    Geppetto.Context.prototype.listen = function listen(target, eventName, callback) {
-        validateListen(target, eventName, callback);
-        return target.listenTo(this.vent, eventName, callback, target);
-    };
-
-    Geppetto.Context.prototype.listenToOnce = function listenToOnce(target, eventName, callback) {
-        validateListen(target, eventName, callback);
-        return target.listenToOnce(this.vent, eventName, callback, target);
-    };
-
-    Geppetto.Context.prototype.dispatch = function dispatch(eventName, eventData) {
-        if (!_.isUndefined(eventData) && !_.isObject(eventData)) {
-            throw "Event payload must be an object";
-        }
-        eventData = eventData || {};
-        eventData.eventName = eventName;
-        this.vent.trigger(eventName, eventData);
-    };
-
-    Geppetto.Context.prototype.dispatchToParent = function dispatchToParent(eventName, eventData) {
-        if (this.parentContext) {
-            this.parentContext.vent.trigger(eventName, eventData);
-        }
-    };
-
-    Geppetto.Context.prototype.dispatchToParents = function dispatchToParents(eventName, eventData) {
-        if (this.parentContext && !(eventData && eventData.propagationDisabled)) {
-            this.parentContext.vent.trigger(eventName, eventData);
-            if (this.parentContext) {
-                this.parentContext.dispatchToParents(eventName, eventData);
-            }
-        }
-    };
-
-    Geppetto.Context.prototype.dispatchGlobally = function dispatchGlobally(eventName, eventData) {
-
-        _.each(contexts, function(context) {
-            if (!context) {
-                return true;
-            }
-            context.vent.trigger(eventName, eventData);
-        });
-    };
-
-    Geppetto.Context.prototype.wireCommand = function wireCommand(eventName, CommandConstructor, wiring) {
-
-        var _this = this;
-
-        if (!_.isFunction(CommandConstructor)) {
-            throw "Command must be constructable";
-        }
-
-        this.vent.listenTo(this.vent, eventName, function(eventData) {
-
-            var commandInstance = new CommandConstructor(_this, eventName, eventData);
-
-            commandInstance.context = _this;
-            commandInstance.eventName = eventName;
-            commandInstance.eventData = eventData;
-            _this.resolver.resolve(commandInstance, wiring);
-            if (_.isFunction(commandInstance.execute)) {
-                commandInstance.execute();
-            }
-
-        }, this);
-    };
-
-    Geppetto.Context.prototype.wireCommands = function wireCommands(commandsMap) {
-        var _this = this;
-        _.each(commandsMap, function(mixedType, eventName) {
-            if (_.isArray(mixedType)) {
-                _.each(mixedType, function(commandClass) {
-                    _this.wireCommand(eventName, commandClass);
-                });
-            } else {
-                _this.wireCommand(eventName, mixedType);
-            }
-        });
-    };
-
-    Geppetto.Context.prototype.wireView = function(key, clazz, wiring) {
-        this.resolver.wireView(key, clazz, wiring);
-        return this;
-    };
-
-    Geppetto.Context.prototype.wireSingleton = function(key, clazz, wiring) {
-        this.resolver.wireSingleton(key, clazz, wiring);
-        return this;
-    };
-
-    Geppetto.Context.prototype.wireValue = function(key, useValue) {
-        this.resolver.wireValue(key, useValue);
-        return this;
-    };
-
-    Geppetto.Context.prototype.wireClass = function(key, clazz, wiring) {
-        this.resolver.wireClass(key, clazz, wiring);
-        return this;
-    };
-
-    Geppetto.Context.prototype.hasWiring = function(key) {
-        return this.resolver.hasWiring(key);
-    };
-
-    Geppetto.Context.prototype.getObject = function(key) {
-        return this.resolver.getObject(key);
-    };
-
-    Geppetto.Context.prototype.instantiate = function(key) {
-        return this.resolver.instantiate(key);
-    };
-
-    Geppetto.Context.prototype.resolve = function(instance, wiring) {
-        this.resolver.resolve(instance, wiring);
-        return this;
-    };
-
-    Geppetto.Context.prototype.release = function(key) {
-        this.resolver.release(key);
-        return this;
-    };
-
-    Geppetto.Context.prototype.releaseAll = function() {
-        this.resolver.releaseAll();
-        return this;
-    };
-
-    Geppetto.Context.prototype.configure = function(key) {
-        this.resolver.configure.apply(this.resolver, arguments);
-        return this;
-    };
-
-    Geppetto.Context.prototype.destroy = function destroy() {
-        this.vent.stopListening();
-        this.resolver.releaseAll();
-
-        delete contexts[this._contextId];
-
-        this.dispatchToParent(Geppetto.EVENT_CONTEXT_SHUTDOWN);
-    };
-
-    Geppetto.Context.extend = Backbone.View.extend;
 
     var debug = {
 

--- a/specs/src/geppetto-specs.js
+++ b/specs/src/geppetto-specs.js
@@ -29,40 +29,11 @@ define([
             afterEach(function() {
                 context.destroy();
             });
-            it("should create an resolver", function() {
-                expect(context.resolver).to.be.an.instanceOf(Geppetto.Resolver);
-            });
-            it("should release its resolvers wirings upon shutdown", function() {
+            it("should release its wirings upon shutdown", function() {
                 var unmapperSpy = sinon.spy();
-                context.resolver.releaseAll = unmapperSpy;
+                context.releaseAll = unmapperSpy;
                 context.destroy();
                 expect(unmapperSpy).to.have.been.calledOnce;
-            });
-            it("should wrap the resolver's methods", function() {
-                var wrapped = [
-                    "wireView",
-                    "wireSingleton",
-                    "wireValue",
-                    "wireClass",
-                    "hasWiring",
-                    "getObject",
-                    "instantiate",
-                    "resolve",
-                    "release",
-                    "releaseAll"
-                ];
-                _.each(wrapped, function(methodName) {
-                    var stub = sinon.stub(context.resolver, methodName);
-                    context[methodName].call(context);
-                    expect(stub).to.have.been.calledOnce;
-                });
-            });
-            it("should use the optionally provided resolver", function(){
-                var child = new Geppetto.Context({
-                    resolver: context.resolver
-                });
-                expect(child.resolver).to.equal(context.resolver);
-                child.destroy();
             });
         });
 
@@ -483,13 +454,11 @@ define([
 
         describe("when triggering commands", function() {
             var context;
-            var resolver;
             var CommandClass;
             var command;
             beforeEach(function() {
                 var ContextDefinition = Geppetto.Context.extend({});
                 context = new ContextDefinition();
-                resolver = context.resolver;
                 CommandClass = function() {
                     this.ctorArgs = _.toArray(arguments);
                 };
@@ -501,14 +470,12 @@ define([
             afterEach(function() {
                 context.destroy();
                 context = null;
-                resolver = null;
-                executionSpy = null;
                 CommandClass = null;
                 command = null;
             });
             it("should resolve dependencies passed to the wireCommand", function() {
                 var value = {};
-                resolver.wireValue('value', value);
+                context.wireValue('value', value);
                 context.wireCommand('foo', CommandClass, {
                     dependency: 'value'
                 });
@@ -518,7 +485,7 @@ define([
 
             it("should resolve dependencies declared in the command", function() {
                 var value = {};
-                resolver.wireValue('value', value);
+                context.wireValue('value', value);
                 CommandClass.prototype.wiring = {
                     dependency: 'value'
                 };
@@ -587,15 +554,13 @@ define([
                 
                 var ContextDefinition = Geppetto.Context.extend({
                     wiring: wiring,
-                    resolver: {
-                        wireSingleton: sinon.spy(),
-                        wireClass: sinon.spy(),
-                        wireValue: sinon.spy(),
-                        wireView: sinon.spy(),
-                        resolve: sinon.spy(),
-                        releaseAll: sinon.spy()
-                    },
-                    initialize : sinon.spy()
+                    initialize : sinon.spy(),
+                    wireSingleton: sinon.spy(),
+                    wireClass: sinon.spy(),
+                    wireValue: sinon.spy(),
+                    wireView : sinon.spy(),
+                    resolve: sinon.spy(),
+                    releaseAll: sinon.spy()
                 });
 
                 context = new ContextDefinition();
@@ -611,31 +576,31 @@ define([
                 expect(abcSpy.called).to.be.true;
             });
             it("should wire singletons", function() {
-                expect(context.resolver.wireSingleton).to.be.calledWith("singleton", wiring.singletons.singleton);
+                expect(context.wireSingleton).to.be.calledWith("singleton", wiring.singletons.singleton);
             });
             it("should wire custom-mapped singletons", function() {
-                expect(context.resolver.wireSingleton).to.be.calledWith("customWiredSingleton", 
+                expect(context.wireSingleton).to.be.calledWith("customWiredSingleton", 
                         wiring.singletons.customWiredSingleton.ctor, wiring.singletons.customWiredSingleton.wiring);
             });
             it("should wire classes", function() {
-                expect(context.resolver.wireClass).to.be.calledWith("clazz", wiring.classes.clazz);
+                expect(context.wireClass).to.be.calledWith("clazz", wiring.classes.clazz);
             });
             it("should wire custom-mapped classes", function() {
-                expect(context.resolver.wireClass).to.be.calledWith("customWiredClass",
+                expect(context.wireClass).to.be.calledWith("customWiredClass",
                         wiring.classes.customWiredClass.ctor, wiring.classes.customWiredClass.wiring);
             });
             it("should wire values", function() {
-                expect(context.resolver.wireValue).to.be.calledWith("value", wiring.values.value);
+                expect(context.wireValue).to.be.calledWith("value", wiring.values.value);
             });
             it("should wire views", function() {
-                expect(context.resolver.wireView).to.be.calledWith("view", wiring.views.view);
+                expect(context.wireView).to.be.calledWith("view", wiring.views.view);
             });
             it("should wire custom-mapped views", function() {
-                expect(context.resolver.wireView).to.be.calledWith("customWiredView",
+                expect(context.wireView).to.be.calledWith("customWiredView",
                         wiring.views.customWiredView.ctor, wiring.views.customWiredView.wiring);
             });
             it("should wire everything before initialization", function(){
-                expect(context.resolver.wireSingleton).to.be.calledBefore(context.initialize);
+                expect(context.wireSingleton).to.be.calledBefore(context.initialize);
             });
         });
 
@@ -726,11 +691,6 @@ define([
                 parentContext.listen(parentView, Geppetto.EVENT_CONTEXT_SHUTDOWN, spy);
                 childView.close();
                 expect(spy.callCount).to.equal(1);
-            });
-
-            it("should have an resolver which is a child resolver of the parent", function() {
-                expect(childContext.resolver.parent).to.equal(parentContext.resolver);
-                expect(childContext.resolver).not.to.equal(parentContext.resolver);
             });
 
         });

--- a/specs/src/resolver-specs.js
+++ b/specs/src/resolver-specs.js
@@ -44,34 +44,26 @@ define([
     
     describe("Backbone.Geppetto.Resolver", function() {
         var context;
-        var resolver;
         beforeEach(function() {
             context = new Geppetto.Context();
-            resolver = context.resolver;
         });
         afterEach(function() {
             context.destroy();
             context = undefined;
-            resolver = undefined;
-        });
-        describe("declaration", function() {
-            it("should be defined as a property on the Geppetto object", function() {
-                expect(Geppetto.Resolver).not.to.be.null;
-            });
         });
         describe("when retrieving objects", function() {
-            it("should poll the parent resolver if no corresponding mapping was found", function(){
+            it("should poll the parent if no corresponding mapping was found", function(){
                 var value = {};
                 var child = new Geppetto.Context({
                     parentContext : context
                 });
-                resolver.wireValue('value', value);
-                var actual = child.resolver.getObject('value');
+                context.wireValue('value', value);
+                var actual = child.getObject('value');
                 expect(actual).to.equal(value);
             });
             it("should throw an error if no corresponding mapping was found", function() {
                 expect(function() {
-                    resolver.getObject('unregistered key');
+                    context.getObject('unregistered key');
                 }).to.
                 throw (/no mapping found/);
             });
@@ -82,14 +74,14 @@ define([
             var key2 = 'key2';
             var value2 = {};
             beforeEach(function() {
-                resolver.wireValue(key1, value1);
-                resolver.wireValue(key2, value2);
+                context.wireValue(key1, value1);
+                context.wireValue(key2, value2);
             });
             it("should accept an array for wiring config", function() {
                 var depender = {
                     wiring: [key1, key2]
                 };
-                resolver.resolve(depender);
+                context.resolve(depender);
                 expect(depender.key1).to.equal(value1);
                 expect(depender.key2).to.equal(value2);
             });
@@ -100,7 +92,7 @@ define([
                         k2: key2
                     }
                 };
-                resolver.resolve(depender);
+                context.resolve(depender);
                 expect(depender.k1).to.equal(value1);
                 expect(depender.k2).to.equal(value2);
             });
@@ -111,37 +103,37 @@ define([
             SingletonClass.prototype.wiring = ['foo'];
             var foo = {};
             beforeEach(function() {
-                resolver.wireValue('foo', foo);
-                resolver.wireSingleton(key, SingletonClass);
+                context.wireValue('foo', foo);
+                context.wireSingleton(key, SingletonClass);
             });
             it('should be determinable', function() {
-                expect(resolver.hasWiring(key)).to.be.true;
+                expect(context.hasWiring(key)).to.be.true;
             });
             it('should produce an instance of the mapped class', function() {
-                var actual = resolver.getObject(key);
+                var actual = context.getObject(key);
                 expect(actual).to.be.an.instanceOf(SingletonClass);
             });
             it('should produce a single, unique instance', function() {
-                var first = resolver.getObject(key);
-                var second = resolver.getObject(key);
+                var first = context.getObject(key);
+                var second = context.getObject(key);
                 expect(second).to.equal(first);
             });
             it("should be instantiatable by brute force", function() {
-                var first = resolver.getObject(key);
-                var second = resolver.instantiate(key);
+                var first = context.getObject(key);
+                var second = context.instantiate(key);
                 expect(second).to.not.equal(first);
             });
             it("should be injected with its dependencies when instantiated", function() {
-                var actual = resolver.getObject(key);
+                var actual = context.getObject(key);
                 expect(actual.foo).to.equal(foo);
             });
             it("should optionally allow wiring configuration", function() {
                 var dependerClass = function() {};
-                resolver.wireSingleton('depender', dependerClass, {
+                context.wireSingleton('depender', dependerClass, {
                     dependency: key
                 });
-                var depender = resolver.getObject('depender');
-                expect(depender.dependency).to.equal(resolver.getObject(key));
+                var depender = context.getObject('depender');
+                expect(depender.dependency).to.equal(context.getObject(key));
             });
             it("should map context events when instantiated", function(){
                 var contextEventSpy = sinon.spy();
@@ -151,7 +143,7 @@ define([
                         contextEventSpy();
                     }
                 };
-                var actual = resolver.getObject(key);
+                var actual = context.getObject(key);
                 context.dispatch('event:foo');
                 expect(contextEventSpy).to.have.been.called;
             });
@@ -160,17 +152,17 @@ define([
             var key = 'a value';
             var value = {};
             beforeEach(function() {
-                resolver.wireValue(key, value);
+                context.wireValue(key, value);
             });
             it('should be determinable', function() {
-                expect(resolver.hasWiring(key)).to.be.true;
+                expect(context.hasWiring(key)).to.be.true;
             });
             it("should be retrievable", function() {
-                expect(resolver.getObject(key)).to.equal(value);
+                expect(context.getObject(key)).to.equal(value);
             });
             it("it should always return the same value", function() {
-                var first = resolver.getObject(key);
-                var second = resolver.getObject(key);
+                var first = context.getObject(key);
+                var second = context.getObject(key);
                 expect(second).to.equal(first);
             });
         });
@@ -180,31 +172,31 @@ define([
             clazz.prototype.wiring = ['foo'];
             var foo = {};
             beforeEach(function() {
-                resolver.wireValue('foo', foo);
-                resolver.wireClass(key, clazz);
+                context.wireValue('foo', foo);
+                context.wireClass(key, clazz);
             });
             it('should be determinable', function() {
-                expect(resolver.hasWiring(key)).to.be.true;
+                expect(context.hasWiring(key)).to.be.true;
             });
             it('should produce an instance of the mapped class', function() {
-                var actual = resolver.getObject(key);
+                var actual = context.getObject(key);
                 expect(actual).to.be.an.instanceOf(clazz);
             });
             it('should produce a new instance every time', function() {
-                var first = resolver.getObject(key);
-                var second = resolver.getObject(key);
+                var first = context.getObject(key);
+                var second = context.getObject(key);
                 expect(second).to.not.equal(first);
             });
             it("should be injected with its dependencies when instantiated", function() {
-                var actual = resolver.getObject(key);
+                var actual = context.getObject(key);
                 expect(actual.foo).to.equal(foo);
             });
             it("should optionally allow wiring configuration", function() {
                 var dependerClass = function() {};
-                resolver.wireClass('depender', dependerClass, {
+                context.wireClass('depender', dependerClass, {
                     dependency: key
                 });
-                var depender = resolver.getObject('depender');
+                var depender = context.getObject('depender');
                 expect(depender.dependency).to.be.an.instanceOf(clazz);
             });
             it("should map context events when instantiated", function(){
@@ -215,7 +207,7 @@ define([
                         contextEventSpy();
                     }
                 };
-                var actual = resolver.getObject(key);
+                var actual = context.getObject(key);
                 context.dispatch('event:foo');
                 expect(contextEventSpy).to.have.been.called;
             });
@@ -226,18 +218,18 @@ define([
             beforeEach(function() {
                 clazz = Backbone.View.extend();
 
-                resolver.wireView(key, clazz);
+                context.wireView(key, clazz);
             });
             it('should be determinable', function() {
-                expect(resolver.hasWiring(key)).to.be.true;
+                expect(context.hasWiring(key)).to.be.true;
             });
             it('should extend the view constructor', function() {
-                var actual = resolver.getObject(key);
+                var actual = context.getObject(key);
                 expect(actual).to.be.a("function");
             });
             it('should retrieve the same class every time', function() {
-                var first = resolver.getObject(key);
-                var second = resolver.getObject(key);
+                var first = context.getObject(key);
+                var second = context.getObject(key);
                 expect(second).to.equal(first);
             });
             it("should call the view's original 'initialize' function when instantiated", function() {
@@ -246,25 +238,25 @@ define([
                 clazz.prototype.initialize = function() {
                     initializeSpy();
                 };
-                var ViewConstructor = resolver.getObject(key);
+                var ViewConstructor = context.getObject(key);
                 var viewInstance = new ViewConstructor();
                 expect(initializeSpy).to.have.been.calledOnce;
             });
             it("should be injected with its dependencies when instantiated", function() {
                 clazz.prototype.wiring = ['foo'];
                 var foo = {};
-                resolver.wireValue('foo', foo);
-                var ViewConstructor = resolver.getObject(key);
+                context.wireValue('foo', foo);
+                var ViewConstructor = context.getObject(key);
                 var viewInstance = new ViewConstructor();
                 expect(viewInstance.foo).to.equal(foo);
             });
             it("should be injected with the context's 'listen' method when instantiated", function() {
-                var ViewConstructor = resolver.getObject(key);
+                var ViewConstructor = context.getObject(key);
                 var viewInstance = new ViewConstructor();
                 expect(viewInstance.listen).to.be.a("function");
             });
             it("should be injected with the context's 'dispatch' method when instantiated", function() {
-                var ViewConstructor = resolver.getObject(key);
+                var ViewConstructor = context.getObject(key);
                 var viewInstance = new ViewConstructor();
                 expect(viewInstance.dispatch).to.be.a("function");
             });
@@ -273,7 +265,7 @@ define([
                 var myContextStub = sinon.stub(context, "listen");
                 var otherContextStub = sinon.stub(otherContext, "listen");
 
-                var ViewConstructor = resolver.getObject(key);
+                var ViewConstructor = context.getObject(key);
                 var viewInstance = new ViewConstructor();
                 expect(myContextStub).not.to.have.been.called;
                 expect(otherContextStub).not.to.have.been.called;
@@ -290,7 +282,7 @@ define([
                 var myContextStub = sinon.stub(context, "dispatch");
                 var otherContextStub = sinon.stub(otherContext, "dispatch");
 
-                var ViewConstructor = resolver.getObject(key);
+                var ViewConstructor = context.getObject(key);
                 var viewInstance = new ViewConstructor();
                 expect(myContextStub).not.to.have.been.called;
                 expect(otherContextStub).not.to.have.been.called;
@@ -304,23 +296,23 @@ define([
             });
             it("should optionally allow wiring configuration", function() {
                 var value = {};
-                resolver.wireValue('value', value);
-                resolver.release(key);
-                resolver.wireView(key, clazz, {
+                context.wireValue('value', value);
+                context.release(key);
+                context.wireView(key, clazz, {
                     dependency: 'value'
                 });
-                var ViewCtor = resolver.getObject(key);
+                var ViewCtor = context.getObject(key);
                 var view = new ViewCtor();
                 expect(view.dependency).to.equal(value);
             });
             it("should optionally allow wiring configuration via the mappings", function() {
                 var value = {};
-                resolver.wireValue('value', value);
-                resolver.release(key);
-                resolver.wireView(key, clazz, {
+                context.wireValue('value', value);
+                context.release(key);
+                context.wireView(key, clazz, {
                     dependency: 'value'
                 });
-                var ViewCtor = resolver.getObject(key);
+                var ViewCtor = context.getObject(key);
                 var view = new ViewCtor();
                 expect(view.dependency).to.equal(value);
             });            
@@ -331,13 +323,13 @@ define([
                         contextEventSpy();
                     }
                 };
-                var ViewCtor = resolver.getObject(key);
+                var ViewCtor = context.getObject(key);
                 var view = new ViewCtor();
                 context.dispatch('event:foo');
                 expect(contextEventSpy).to.have.been.called;
             });
             it("should be a factory method (as well)", function(){
-                var factory = resolver.getObject(key);
+                var factory = context.getObject(key);
                 var view = factory();
                 expect(view).to.be.instanceOf(clazz);
             });
@@ -347,15 +339,15 @@ define([
                 clazz.prototype.initialize = function() {
                     initializeSpy();
                 };
-                var factory = resolver.getObject(key);
+                var factory = context.getObject(key);
                 var viewInstance = factory();
                 expect(initializeSpy).to.have.been.calledOnce;
             });
             it("should be injected with its dependencies when instantiated by the factory", function() {
                 clazz.prototype.wiring = ['foo'];
                 var foo = {};
-                resolver.wireValue('foo', foo);
-                var factory = resolver.getObject(key);
+                context.wireValue('foo', foo);
+                var factory = context.getObject(key);
                 var viewInstance = factory();
                 expect(viewInstance.foo).to.equal(foo);
             });
@@ -371,7 +363,7 @@ define([
                     }
                 });
                 var originalModel = new clazz(obj1, obj2);
-                var wrappedClazz = resolver._wrapConstructor(clazz, null);
+                var wrappedClazz = context._wrapConstructor(clazz, null);
                 var wrappedModel = new wrappedClazz(obj1, obj2);
                 expect(originalModel.obj1).to.eql(wrappedModel.obj1);
                 expect(originalModel.obj2).to.eql(wrappedModel.obj2)
@@ -384,8 +376,8 @@ define([
             it("should have its dependencies fulfilled", function() {
                 value.wiring = ['foo'];
                 var foo = {};
-                resolver.wireValue('foo', foo);
-                resolver.resolve(value);
+                context.wireValue('foo', foo);
+                context.resolve(value);
                 expect(value.foo).to.equal(foo);
             });
         });
@@ -393,15 +385,15 @@ define([
             var key = 'a value';
             var value = {};
             beforeEach(function() {
-                resolver.wireValue(key, value);
-                resolver.release(key);
+                context.wireValue(key, value);
+                context.release(key);
             });
             it('should be determinable', function() {
-                expect(resolver.hasWiring(key)).to.be.false;
+                expect(context.hasWiring(key)).to.be.false;
             });
             it("should not be retrievable", function() {
                 expect(function() {
-                    resolver.getObject(key);
+                    context.getObject(key);
                 }).to.
                 throw (/no mapping found/);
             });
@@ -420,15 +412,15 @@ define([
             });
             beforeEach(function(){
                 clazzInstantiated=0;
-                resolver.wireClass('clazz', clazz);
-                resolver.wireSingleton('singleton', singleton);
+                context.wireClass('clazz', clazz);
+                context.wireSingleton('singleton', singleton);
             });
             it("should not resolve singleton dependencies twice, see #51", function(){
-                var actual = resolver.getObject('singleton');
+                var actual = context.getObject('singleton');
                 expect(clazzInstantiated ).to.equal(1);
             });
             it("should resolve dependencies before initialization", function(){
-                var actual = resolver.getObject('singleton');
+                var actual = context.getObject('singleton');
                 expect(resolvedDependency ).to.be.instanceOf(clazz);
             });
         });


### PR DESCRIPTION
Hi @geekdave a number of fixes, and improvements:
1. I fixed the double line as mentioned by @mmikeyy 
2. Optimized the `applyToConstructor` function
3. Added a factory/constructor method for views as proposed in #50 which means you can use injected views either as a factory function or as a constructor function
4. Fully refactored Geppetto. This simply means I merged the `Resolver` object into the `Context`. The separation made sense when we started out with the DI, but it had become a weird mess with some wire\* methods hanging directly on the context others in resolver etc. In fact, two classes weren't necessary since they were tightly coupled anyway.

If you don't like any of this either cherry-pick the ones you do or let me know and I'll do it for you.
