### PR TITLE
dispatchToParents problem

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -202,27 +202,32 @@
             return target.listenToOnce(this.vent, eventName, callback, target);
         },
 
-        dispatch: function dispatch(eventName, eventData) {
+        _extendEventData: function(eventName, eventData) {
             if (!_.isUndefined(eventData) && !_.isObject(eventData)) {
                 throw "Event payload must be an object";
             }
             eventData = eventData || {};
             eventData.eventName = eventName;
+            return eventData;
+        },
+
+        dispatch: function dispatch(eventName, eventData) {
+            eventData = this._extendEventData(eventName, eventData);
             this.vent.trigger(eventName, eventData);
         },
 
         dispatchToParent: function dispatchToParent(eventName, eventData) {
             if (this.parentContext) {
-                this.parentContext.vent.trigger(eventName, eventData);
+                this.parentContext.dispatch(eventName, eventData);
             }
         },
 
         dispatchToParents: function dispatchToParents(eventName, eventData) {
-            if (this.parentContext && !(eventData && eventData.propagationDisabled)) {
-                this.parentContext.vent.trigger(eventName, eventData);
-                if (this.parentContext) {
-                    this.parentContext.dispatchToParents(eventName, eventData);
-                }
+            eventData = this._extendEventData(eventName, eventData);
+            var context = this.parentContext;
+            while (context && !eventData.propagationDisabled) {
+                context.vent.trigger(eventName, eventData);
+                context = context.parentContext;
             }
         },
 


### PR DESCRIPTION
Hey all... Not a big problem but still. 

We allow propagation to be stopped by extending the payload with  `{propagationDisabled:true }`.
Problem is that all events dispatched do not have a payload attached to them. Events without a payload cannot have their propagation stopped.

Solution is to always replace undefined payload with an empty object, all simply. I can't see any negative side effect. 

Also, there seems to be an inconsistency in the treatment of the payload between `dispatch`, `dispatchToParent` and `dispatchToParents`.

The first one checks that the payload is an object, if defined: 

```
        dispatch: function dispatch(eventName, eventData) {
            if (!_.isUndefined(eventData) && !_.isObject(eventData)) {
                throw "Event payload must be an object";
            }
            eventData = eventData || {};
            eventData.eventName = eventName;
            this.vent.trigger(eventName, eventData);
        },
```

Ahh! I hadn't noticed but here we see the payload set to an empty object by default!!!

The second one does no checking at all on the payload and just triggers the event on the target with whatever is supplied as payload:

```
           dispatchToParent: function dispatchToParent(eventName, eventData) {
            if (this.parentContext) {
                this.parentContext.vent.trigger(eventName, eventData);
            }
        },
```

For `dispatchToParent`, instead of 

```
this.parentContext.vent.trigger(eventName, eventData);
```

we should have 

```
 this.parentContext.dispatch(eventName, eventData);
```

and dispatchToParents could be fixed the same way.

Another benefit is that eventName would be added to payload in all cases, and not just for one of the three flavors (improved consistency)

Let me know if I'm missing something.

Let me know also if you want me to do PR, tests et all.

PS congratulations @creynders on your recent anointment as knight of the Geppetto realm! BTW, could you put on your shining armor and quickly explain something to me? I forked the repository at a certain point in time and then branched from it for the PR's that I made. That worked well. But now that  the main repository has moved to 0.7.1, I find my fork to be outdated and I've been looking all over the user interface for a way to simply reset it to be equal to the main repository. Can't find anything. Is one supposed to delete his fork and fork again? (or ... should I just RTFM?)
