### PR TITLE
Rename `wireView` or provide an alias

### DIFF
--- a/backbone.geppetto.js
+++ b/backbone.geppetto.js
@@ -28,7 +28,7 @@
     var NO_MAPPING_FOUND = 'no mapping found for key: ';
     var TYPES = {
         SINGLETON: 'singleton',
-        VIEW: 'view',
+        FACTORY: 'factory',
         OTHER: 'other'
     };
 
@@ -149,7 +149,7 @@
                     }
                     output = config.object;
                 } else {
-                    if (config.type === TYPES.VIEW) {
+                    if (config.type === TYPES.FACTORY) {
                         output = config.clazz;
                     } else if (config.clazz) {
                         output = this._createAndSetupInstance(config);
@@ -292,10 +292,14 @@
         },
 
         wireView: function(key, clazz, wiring) {
+            this.wireFactory(key, clazz, wiring);
+        },
+
+        wireFactory: function(key, clazz, wiring) {
             this._mappings[key] = {
                 clazz: createFactory(this._wrapConstructor(clazz, wiring)),
                 object: null,
-                type: TYPES.VIEW
+                type: TYPES.FACTORY
             };
             return this;
         },
@@ -316,7 +320,7 @@
             if (typeof mapping === 'undefined') {
                 throw new Error(NO_MAPPING_FOUND + key);
             }
-            if (!mapping.clazz || mapping.type === TYPES.VIEW) {
+            if (!mapping.clazz || mapping.type === TYPES.FACTORY) {
                 throw new Error("Cannot configure " + key + ": only possible for wirings of type singleton or class");
             }
             mapping.params = _.toArray(arguments).slice(1);

--- a/specs/src/resolver-specs.js
+++ b/specs/src/resolver-specs.js
@@ -212,6 +212,30 @@ define([
                 expect(contextEventSpy).to.have.been.called;
             });
         });
+        describe("when mapping a factory", function(){
+            var key = 'a class';
+            var clazz = function(){};
+            beforeEach(function() {
+                context.wireFactory(key, clazz);
+            });
+            it('should be determinable', function() {
+                expect(context.hasWiring(key)).to.be.true;
+            });
+            it('should return a function', function(){
+                var factory = context.getObject(key);
+                expect(factory ).to.be.a.function;
+            });
+            it('should create an instance of the mapped class with `new`', function(){
+                var wrapped = context.getObject(key);
+                var instance = new wrapped();
+                expect(instance ).to.be.instanceOf(clazz);
+            });
+            it('should create an instance of the mapped class when called', function(){
+                var factory = context.getObject(key);
+                var instance = factory();
+                expect(instance ).to.be.instanceOf(clazz);
+            });
+        });
         describe("when mapping a view", function() {
             var key = 'a class';
             var clazz;


### PR DESCRIPTION
I encountered a situation (once again) where I'm wiring something else than a view with `wireView` since I need it to be injected as a class instead of an instance. In this case a model in a collection.

The collection handles instantiation, but I need the models to receive dependency injections. It's a bit of a rare case, since normally my models don't have any dependencies, but this is an aggregate model, i.e. it manages a number of other models (and collections)

@geekdave I think the easiest will be to provide an alias, something like `wireFactory`? If at some point in time we need to differentiate between `wireFactory` and `wireView` that won't be a problem.
