### PR TITLE
Add aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,26 @@ context.wireValue("answerToLifeTheUniverseAndEverything", 42);
 
 Dependants are injected with the value itself.
 
+#### Aliases
+
+Any wiring can be aliased, which means it will be reused with another key. You can do this either with:
+
+1. `createAlias`
+
+	```js
+	context.wireSingleton('userModel', UserModel);
+	context.createAlias('userModel', 'accountModel');
+	```
+
+1. or any of the wire* methods by providing an Array of keys
+
+	```js
+	context.wireSingleton(['userModel', 'accountModel'], UserModel);
+	```
+
+In both examples all dependants that have declared "userModel" or "accountModel" as a dependency will receive the same singleton instance.
+
+
 ### Wiring at the Component Level
 
 Example injecting a model into a view.

--- a/specs/src/resolver-specs.js
+++ b/specs/src/resolver-specs.js
@@ -376,6 +376,37 @@ define([
                 expect(viewInstance.foo).to.equal(foo);
             });
         });
+        describe("when mapping keys", function(){
+            it("should throw an error for keys other than String or Array", function(){
+                expect(function() {
+                    context.wireSingleton({},{});
+                }).to.
+                throw (/Key must be of type/);
+            });
+            it("should throw an error for an Array of anything else but String", function(){
+                expect(function() {
+                    context.wireSingleton([{}],{});
+                }).to.
+                throw (/Key must be of type/);
+            });
+            it("should use the same mapping for all keys", function(){
+                var singleton = function(){};
+                context.wireSingleton(["s1", "s2"], singleton);
+                var s1 = context.getObject("s1");
+                var s2 = context.getObject("s2");
+                expect(s2).to.equal(s1);
+            });
+        });
+        describe("when creating aliases", function(){
+            it("should reuse the aliased mapping", function(){
+                var singleton = function(){};
+                context.wireSingleton("s1", singleton);
+                context.createAlias("s1", "s2");
+                var s1 = context.getObject("s1");
+                var s2 = context.getObject("s2");
+                expect(s2).to.equal(s1);
+            });
+        });
         describe("when wrapping a constructor", function() {
             it("should allow wrapped constructor to handle initialization parameters in similar fashion as unwrapped constructor)", function() {
                 var obj1 = {value: 'foo'};


### PR DESCRIPTION
Allows registering an object to multiple keys at once or later on through `Context#createAlias`
