### PR TITLE
Change SemVer of dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,12 +36,15 @@
     "sinon-chai": "~2.4.0",
     "blanket": "~1.1.5",
     "sinonjs": "~1.7.3",
-    "marionette": "~1.4.1",
+    "marionette": "^1.4.1",
     "handlebars": "1.3.0",
     "jquery-mockjax": "1.5.3"
   },
   "dependencies": {
-    "backbone": "~1.1.0",
-    "underscore": "~1.5.2"
+    "backbone": "^1.1.0",
+    "underscore": "^1.5.2"
+  },
+  "resolutions": {
+    "underscore": ">=1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "dependency injection"
   ],
   "dependencies": {
-    "backbone": "~1.1.0",
-    "underscore": "^1.6.0"
+    "backbone": "^1.1.0",
+    "underscore": "^1.5.2"
   },
   "contributors":[
     "geekdave (https://github.com/geekdave)",


### PR DESCRIPTION
The semantic versioning for the dependencies backbone and underscore where to unspecific for current releases of them. When using tools like JSPM it's complicated to target newer releases as dependencies.
